### PR TITLE
Add endpoints to retrieve list of subjects

### DIFF
--- a/functions/build/routes.ts
+++ b/functions/build/routes.ts
@@ -6,6 +6,8 @@ import { Controller, ValidationService, FieldErrors, ValidateError, TsoaRoute, H
 import { CoursesController } from './../src/courses/Course.controller';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { SectionsController } from './../src/sections/Section.controller';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { SubjectsController } from './../src/subjects/Subject.controller';
 import * as express from 'express';
 
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -126,6 +128,20 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "KualiSubject": {
+        "dataType": "refObject",
+        "properties": {
+            "subject": {"dataType":"string","required":true},
+            "title": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Subject": {
+        "dataType": "refAlias",
+        "type": {"ref":"KualiSubject","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
 const validationService = new ValidationService(models);
 
@@ -226,6 +242,28 @@ export function RegisterRoutes(app: express.Router) {
 
 
             const promise = controller.seats.apply(controller, validatedArgs as any);
+            promiseHandler(controller, promise, response, undefined, next);
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/subjects/:term',
+            function (request: any, response: any, next: any) {
+            const args = {
+                    term: {"in":"path","name":"term","required":true,"ref":"Term"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+            } catch (err) {
+                return next(err);
+            }
+
+            const controller = new SubjectsController();
+
+
+            const promise = controller.subjects.apply(controller, validatedArgs as any);
             promiseHandler(controller, promise, response, undefined, next);
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/functions/build/swagger.json
+++ b/functions/build/swagger.json
@@ -342,6 +342,25 @@
 				],
 				"type": "object",
 				"additionalProperties": false
+			},
+			"KualiSubject": {
+				"properties": {
+					"subject": {
+						"type": "string"
+					},
+					"title": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"subject",
+					"title"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Subject": {
+				"$ref": "#/components/schemas/KualiSubject"
 			}
 		},
 		"securitySchemes": {}
@@ -516,6 +535,40 @@
 						"required": true,
 						"schema": {
 							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/subjects/{term}": {
+			"get": {
+				"operationId": "Subjects",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"items": {
+										"$ref": "#/components/schemas/Subject"
+									},
+									"type": "array"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Subjects"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "term",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/Term"
 						}
 					}
 				]

--- a/functions/src/subjects/Subject.controller.ts
+++ b/functions/src/subjects/Subject.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Path, Route, Tags } from 'tsoa';
+import { Term } from '../constants';
+import { Subject } from './Subject.model';
+import { SubjectsService } from './Subject.service';
+
+@Route('subjects')
+export class SubjectsController extends Controller {
+  @Get('{term}')
+  @Tags('Subjects')
+  public async subjects(@Path() term: Term): Promise<Subject[]> {
+    this.setHeader(
+      'Cache-Control',
+      `public, max-age=${3600}, s-max-age=${1800}`
+    );
+    return await new SubjectsService().getSubjects(term);
+  }
+}

--- a/functions/src/subjects/Subject.model.ts
+++ b/functions/src/subjects/Subject.model.ts
@@ -1,0 +1,3 @@
+import { KualiSubject } from '@vikelabs/uvic-course-scraper/dist';
+
+export type Subject = KualiSubject;

--- a/functions/src/subjects/Subject.service.ts
+++ b/functions/src/subjects/Subject.service.ts
@@ -1,0 +1,14 @@
+import { UVicCourseScraper } from '@vikelabs/uvic-course-scraper/dist';
+import { Term } from '../constants';
+import { Subject } from './Subject.model';
+
+export class SubjectsService {
+  public async getSubjects(term: Term): Promise<Subject[]> {
+    const subjects = await UVicCourseScraper.getSubjects(term);
+    return subjects.map(({ subject, title }) => ({
+      subject,
+      // removes the subject within the title
+      title: title.replace(`(${subject})`, '').trim(),
+    }));
+  }
+}


### PR DESCRIPTION
Adds `/subjects/{term}` to get a list of subjects with their respective title and shortform. 