### PR TITLE
fix: don't throw and just return an empty array

### DIFF
--- a/functions/src/sections/Section.service.ts
+++ b/functions/src/sections/Section.service.ts
@@ -3,7 +3,6 @@ import { UVicCourseScraper } from '@vikelabs/uvic-course-scraper/dist/index';
 import { db } from '../db/firestore';
 import { subjectCodeExtractor } from '../shared/subjectCodeExtractor';
 import { Term } from '../constants';
-import { SectionNotFoundError } from '../errors/errors';
 
 export class SectionsService {
   public async getSections(
@@ -38,7 +37,7 @@ export class SectionsService {
         })
       );
     }
-    throw new SectionNotFoundError('Seats Not Found');
+    return [];
   }
 
   public async getSectionMapping(


### PR DESCRIPTION
the 500 reponse is useless for us at the moment and we don't do anything with it so and it doesn't cache so it's pretty bad for performance too. 