### PR TITLE
Fix maximum depth bug

### DIFF
--- a/src/app/header/components/TermButtons.tsx
+++ b/src/app/header/components/TermButtons.tsx
@@ -4,12 +4,12 @@ import React, { useContext, useEffect, useState } from 'react';
 import { TermContext } from '../../context/TermContext';
 import { getCurrentTerms, getReadableTerm } from '../../shared/utils/terms';
 
+const terms = getCurrentTerms();
+
 export function TermButtons(): JSX.Element {
   const [status, setStatus] = useState([false, false, false]);
 
   const { term, setTerm } = useContext(TermContext);
-
-  const terms = getCurrentTerms();
 
   //initally the current term button needs to be set active to reflect the default term of the context
   useEffect(() => {
@@ -17,7 +17,7 @@ export function TermButtons(): JSX.Element {
     const initStatus = [false, false, false];
     initStatus[idx] = true;
     setStatus(initStatus);
-  }, [term, terms]);
+  }, [term]);
 
   const onClick = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
     event.preventDefault();


### PR DESCRIPTION
Fixed a bug where the maximum depth was being exceeded from the `useEffect` call in `TermButtons.tsx`. The variable `terms` was being called within the method which caused an infinite loop.