### PR TITLE
feat: Add filtering of courses based on availibility 

### DIFF
--- a/functions/build/routes.ts
+++ b/functions/build/routes.ts
@@ -18,7 +18,6 @@ const models: TsoaRoute.Models = {
         "properties": {
             "pid": {"dataType":"string","required":true},
             "title": {"dataType":"string","required":true},
-            "dateStart": {"dataType":"string","required":true},
             "subject": {"dataType":"string","required":true},
             "code": {"dataType":"string","required":true},
         },
@@ -35,8 +34,8 @@ const models: TsoaRoute.Models = {
         "properties": {
             "pid": {"dataType":"string","required":true},
             "title": {"dataType":"string","required":true},
-            "dateStart": {"dataType":"string","required":true},
             "description": {"dataType":"string","required":true},
+            "dateStart": {"dataType":"string","required":true},
             "credits": {"dataType":"nestedObjectLiteral","nestedProperties":{"chosen":{"dataType":"string","required":true},"value":{"dataType":"string","required":true},"credits":{"dataType":"nestedObjectLiteral","nestedProperties":{"max":{"dataType":"string","required":true},"min":{"dataType":"string","required":true}},"required":true}},"required":true},
             "subject": {"dataType":"string","required":true},
             "code": {"dataType":"string","required":true},
@@ -156,6 +155,7 @@ export function RegisterRoutes(app: express.Router) {
             function (request: any, response: any, next: any) {
             const args = {
                     term: {"in":"path","name":"term","required":true,"ref":"Term"},
+                    in_session: {"default":false,"in":"query","name":"in_session","dataType":"boolean"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/functions/build/swagger.json
+++ b/functions/build/swagger.json
@@ -14,9 +14,6 @@
 					"title": {
 						"type": "string"
 					},
-					"dateStart": {
-						"type": "string"
-					},
 					"subject": {
 						"type": "string"
 					},
@@ -27,7 +24,6 @@
 				"required": [
 					"pid",
 					"title",
-					"dateStart",
 					"subject",
 					"code"
 				],
@@ -52,10 +48,10 @@
 					"title": {
 						"type": "string"
 					},
-					"dateStart": {
+					"description": {
 						"type": "string"
 					},
-					"description": {
+					"dateStart": {
 						"type": "string"
 					},
 					"credits": {
@@ -108,8 +104,8 @@
 				"required": [
 					"pid",
 					"title",
-					"dateStart",
 					"description",
+					"dateStart",
 					"credits",
 					"subject",
 					"code"
@@ -398,6 +394,15 @@
 						"required": true,
 						"schema": {
 							"$ref": "#/components/schemas/Term"
+						}
+					},
+					{
+						"in": "query",
+						"name": "in_session",
+						"required": false,
+						"schema": {
+							"default": false,
+							"type": "boolean"
 						}
 					}
 				]

--- a/functions/src/courses/Course.controller.ts
+++ b/functions/src/courses/Course.controller.ts
@@ -17,7 +17,7 @@ export class CoursesController extends Controller {
       'Cache-Control',
       `public, max-age=${3600}, s-max-age=${3600}, stale-while-revalidate=${30}, stale-if-error=${60}`
     );
-    return new CoursesService().getCourses(term);
+    return CoursesService.getCourses(term);
   }
 
   /**
@@ -35,6 +35,6 @@ export class CoursesController extends Controller {
       'Cache-Control',
       `public, max-age=${3600}, s-max-age=${3600}, stale-while-revalidate=${30}, stale-if-error=${60}`
     );
-    return new CoursesService().getCourseDetailsByPid(term, pid);
+    return CoursesService.getCourseDetailsByPid(term, pid);
   }
 }

--- a/functions/src/courses/Course.controller.ts
+++ b/functions/src/courses/Course.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Path, Route } from 'tsoa';
+import { Controller, Get, Path, Query, Route } from 'tsoa';
 import { Term } from '../constants';
 import { Course, CourseDetails } from './Course.model';
 import { CoursesService } from './Course.service';
@@ -11,13 +11,16 @@ export class CoursesController extends Controller {
    * @param code
    */
   @Get('{term}')
-  public async getCourses(@Path() term: Term): Promise<Course[]> {
+  public async getCourses(
+    @Path() term: Term,
+    @Query() in_session = false
+  ): Promise<Course[]> {
     // set the Cache-Control for 24h.
     this.setHeader(
       'Cache-Control',
       `public, max-age=${3600}, s-max-age=${3600}, stale-while-revalidate=${30}, stale-if-error=${60}`
     );
-    return CoursesService.getCourses(term);
+    return CoursesService.getCourses(term, in_session);
   }
 
   /**

--- a/functions/src/courses/Course.model.ts
+++ b/functions/src/courses/Course.model.ts
@@ -3,8 +3,7 @@ import {
   KualiCourseItem,
 } from '@vikelabs/uvic-course-scraper/dist/types';
 
-export interface Course
-  extends Pick<KualiCourseCatalog, 'pid' | 'title' | 'dateStart'> {
+export interface Course extends Pick<KualiCourseCatalog, 'pid' | 'title'> {
   subject: string;
   code: string;
 }

--- a/functions/src/courses/Course.service.ts
+++ b/functions/src/courses/Course.service.ts
@@ -4,7 +4,7 @@ import { subjectCodeExtractor } from '../shared/subjectCodeExtractor';
 import { Term } from '../constants';
 
 export class CoursesService {
-  public async getCourses(term: Term): Promise<Course[]> {
+  static async getCourses(term: Term): Promise<Course[]> {
     const courses = await UVicCourseScraper.getCourses(term);
     return courses.map((course) => ({
       ...subjectCodeExtractor(course),
@@ -14,7 +14,7 @@ export class CoursesService {
     }));
   }
 
-  public async getCourseDetailsByPid(
+  static async getCourseDetailsByPid(
     term: string,
     pid: string
   ): Promise<CourseDetails> {

--- a/functions/src/courses/Course.service.ts
+++ b/functions/src/courses/Course.service.ts
@@ -2,13 +2,44 @@ import { Course, CourseDetails } from './Course.model';
 import { UVicCourseScraper } from '@vikelabs/uvic-course-scraper/dist/index';
 import { subjectCodeExtractor } from '../shared/subjectCodeExtractor';
 import { Term } from '../constants';
+import { query, where, batch, ref, get, update, set } from 'typesaurus';
+import {
+  CourseDoc,
+  CoursesCollection,
+  SectionsSubstore,
+} from '../db/collections';
+import { getSections } from '../sections/Section.service';
 
 export class CoursesService {
-  static async getCourses(term: Term): Promise<Course[]> {
+  /**
+   *
+   * @param term ie. 202101
+   * @param inSessionOnly if true, will only return courses that are in session.
+   * @returns Promise<Course[]>
+   */
+  static async getCourses(
+    term: Term,
+    inSessionOnly = false
+  ): Promise<Course[]> {
+    // only return courses that are in session for the given term.
+    if (inSessionOnly) {
+      // only return courses
+      const results = await query(CoursesCollection, [
+        where('inSession', '==', true),
+        where('term', '==', term),
+      ]);
+
+      return results.map(({ data: { subject, code, title, pid } }) => ({
+        subject,
+        code,
+        pid,
+        title,
+      }));
+    }
+
     const courses = await UVicCourseScraper.getCourses(term);
     return courses.map((course) => ({
       ...subjectCodeExtractor(course),
-      dateStart: course.dateStart,
       pid: course.pid,
       title: course.title,
     }));
@@ -28,4 +59,166 @@ export class CoursesService {
       credits: course.credits,
     };
   }
+
+  /**
+   * Populates the database with course information required to make advanced queries and
+   * fast requests to sub-resources (like sections, seats), which require a CRN.
+   * NOTE: the assumption is this won't be run very often.
+   * @param term
+   */
+  static async populateCourses(term: Term): Promise<void> {
+    console.log('fetching courses...');
+    const courses = await CoursesService.getCourses(term);
+    // get all sections for a given term and course
+    console.log('fetching sections...');
+    const sections = await Promise.all(
+      courses.map(async ({ subject, code, title, pid }) => ({
+        // makes iterating over the data easier if we have the subject and code.
+        sections: await getSections(term, subject, code),
+        subject,
+        code,
+        title,
+        pid,
+      }))
+    );
+
+    console.log('inserting into db');
+
+    let j = 0;
+    let { set, commit } = batch();
+    for (let i = 0; i < sections.length; i++) {
+      // Each batch can be up to 500 set, update and remove operations
+      const course = sections[i];
+      const { subject, code, title, pid } = course;
+
+      const crns = course.sections.map((c) => c.crn);
+
+      set(CoursesCollection, constructSectionKey(term, subject, code), {
+        term,
+        pid,
+        title,
+        subject,
+        code,
+        crns,
+        inSession: crns.length > 0 ? true : false,
+        createdAt: new Date(Date.now()),
+      });
+      j++;
+
+      const id = constructSectionKey(term, subject, code);
+      const courseRef = ref(CoursesCollection, id);
+
+      // insert into data into subcollection
+      course.sections.map(async ({ crn }) => {
+        return set(SectionsSubstore(id), crn, {
+          course: courseRef,
+          crn,
+        });
+      });
+
+      j += course.sections.length;
+      // 450 is a "soft" limit on how many write operations that can be batched together.
+      // since the sections we can't really gauge, it's simpler to set a safer upper bound.
+      // this code will only fail if the num of sections in a given class is greater than 50.
+
+      if (j > 450) {
+        console.log('batch', j);
+        await commit();
+        // FIX: this is a workaround for an "weird" bug.
+        // the set/commit need to be re-created from batch() to "flush" the batch writes.
+        // https://stackoverflow.com/questions/61666244/invalid-argument-maximum-500-writes-allowed-per-request-firebase-cloud-functi
+        const { set: a, commit: b } = batch();
+        set = a;
+        commit = b;
+        j = 0;
+      }
+    }
+  }
+}
+
+export async function getCourse(
+  term: string,
+  subject: string,
+  code: string
+): Promise<CourseDoc | undefined> {
+  const doc = await get(
+    CoursesCollection,
+    constructSectionKey(term, subject, code)
+  );
+  return doc?.data;
+}
+
+export async function setCourse(
+  term: string,
+  subject: string,
+  code: string
+): Promise<CourseDoc | undefined> {
+  const courses = await UVicCourseScraper.getCourses(term);
+
+  const key = constructSectionKey(term, subject, code);
+
+  // we need the pid so this is currently the "best" (or only way) to get it if we don't have a record in the database.
+  const course = courses.find((c) => `${term}${c.subjectCode}` === key);
+
+  if (!course) return undefined;
+
+  const sections = await UVicCourseScraper.getCourseSections(
+    term,
+    subject,
+    code
+  );
+
+  const crns = sections.map((c) => c.crn);
+
+  const doc = {
+    subject,
+    code,
+    title: course.title,
+    pid: course.pid,
+    term,
+    crns,
+    inSession: crns.length > 0 ? true : false,
+    createdAt: new Date(Date.now()),
+  };
+
+  await set(CoursesCollection, key, doc);
+  return doc;
+}
+
+export async function updateCourse(
+  term: string,
+  subject: string,
+  code: string
+): Promise<void> {
+  try {
+    const sections = await UVicCourseScraper.getCourseSections(
+      term,
+      subject,
+      code
+    );
+
+    if (sections.length > 0) {
+      const crns = sections.map(({ crn }) => crn);
+      const retrievedAt = new Date(Date.now());
+      await update(
+        CoursesCollection,
+        constructSectionKey(term, subject, code),
+        {
+          crns,
+          inSession: crns.length > 0 ? true : false,
+          updatedAt: retrievedAt,
+        }
+      );
+    }
+  } catch (e) {
+    console.warn(e);
+  }
+}
+
+export function constructSectionKey(
+  term: string,
+  subject: string,
+  code: string
+): string {
+  return `${term}${subject}${code}`;
 }

--- a/functions/src/db/collections.ts
+++ b/functions/src/db/collections.ts
@@ -1,6 +1,38 @@
-import { collection as FirestoreCollection } from 'typesaurus';
-import { CourseMapping } from '../sections/Section.model';
+import { collection, subcollection, Ref } from 'typesaurus';
 
-const courseMappings = FirestoreCollection<CourseMapping>('section_mappings');
+export type CourseDoc = {
+  // human metadata
+  title: string;
+  subject: string;
+  code: string;
+  // indexed / query
+  term: string;
+  // course metadata
+  pid: string;
+  crns: string[];
+  // if crns.length > 0 then true else false.
+  inSession: boolean;
 
-export const collection = { courseMappings };
+  // datetime metadata
+  createdAt: Date;
+  updatedAt?: Date;
+};
+
+export type SectionDoc = {
+  // parent-collection ref
+  course: Ref<CourseDoc>;
+  //
+  crn: string;
+  instructors?: string[];
+};
+
+// highest level collection
+const CoursesCollection = collection<CourseDoc>('courses');
+
+// subcollection of Course
+const SectionsSubstore = subcollection<SectionDoc, CourseDoc>(
+  'sections',
+  CoursesCollection
+);
+
+export { CoursesCollection, SectionsSubstore };

--- a/functions/src/sections/Section.model.ts
+++ b/functions/src/sections/Section.model.ts
@@ -8,8 +8,3 @@ export type Section = ClassScheduleListing;
 export interface Seat extends DetailedClassInformation {
   crn: string;
 }
-
-export interface CourseMapping {
-  crns: string[];
-  retrievedAt?: Date;
-}

--- a/functions/src/server.ts
+++ b/functions/src/server.ts
@@ -10,7 +10,7 @@ import * as openapi from '../build/swagger.json';
 
 export const app = express();
 
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 3001;
 
 // Use body parser to read sent json payloads
 app.use(


### PR DESCRIPTION
# THIS IS A CHONKER PREPARE YOURSELF
This PR changes the usage of Firestore significantly in order to allow more features in regards to data queries. 

The goal of this PR is to allow courses to be filtered based on whether they are in session for a given term. This allows the application to only show courses that are in session. 

The previous way we were storing course metadata (`course_mappings`, which stored the CRNs for a given course and term ie. `202101SENG265`) 

This did not allow query based on an attribute since the `term` was not stored. The only way to query would be to get all the keys and do some string manipulation on the key itself. That seemed janky so this restructures how data is stored in Firebase.

## Firestore
The key is still constructed the same way where the `term`, `subject`, `code` and `crns` are also stored, however `term` and other fields are added into the document. Section specific data is stored as a subcollection. This results in a document key for a section being `202101SENG265/sections/10001` which would reference a single section document (check the `collections.ts` for details)

## Data Ingest
In order to allow the filtering, we need to have the data on all courses for a given term. Minimally speaking this means the number of sections for a course in a term. This allows the backend to determine if a course is in session (by checking if any CRNs exist for that class). As a result this PR adds a script to populate the database with the required data as a ETL operation. In the future we will need to make the backend periodically refresh (or invalidate) data but for this PR we leave that as future work.
