### PR TITLE
Enable Firebase Preview Builds

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -57,6 +57,25 @@ jobs:
         with:
           name: create-react-app-build
           path: build
+  deploy-preview:
+    name: Deploy to Firebase Hosting Preview
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [ lint, build ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: create-react-app-build
+          path: build
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          expires: 7d
+          projectId: staging-clockwork
   deploy:
     name: Deploy to Firebase Hosting (Staging)
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -11,6 +11,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'functions/**'
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Enables temporary frontend build and hosting when a PR is made. The build/hosting lasts 1 week.