### PR TITLE
Add links to UVic pages at bottom of content

### DIFF
--- a/src/app/content/Content.tsx
+++ b/src/app/content/Content.tsx
@@ -20,7 +20,6 @@ export type ContentProps = {
 export function Content({ term }: ContentProps): JSX.Element {
   const [searchParams] = useSearchParams();
   const { data, loading } = useGetCourse({ term, pid: searchParams.get('pid') || '' });
-  console.log(data);
 
   return (
     <Flex width={['container.md', 'container.lg', 'container.xl']} flexDirection="column" minH="100%">

--- a/src/app/content/Content.tsx
+++ b/src/app/content/Content.tsx
@@ -57,7 +57,7 @@ export function Content({ term }: ContentProps): JSX.Element {
       </Box>
       <Spacer />
       <Center>
-        <Text as="span" fontWeight="bold" fontSize={12}>
+        <Text as="span" fontWeight="bold" fontSize={12} mb={5}>
           Sources:
           <Text as="span" color="blue.500" fontWeight="light">
             <Text

--- a/src/app/content/Content.tsx
+++ b/src/app/content/Content.tsx
@@ -53,8 +53,8 @@ export function Content({ term }: ContentProps): JSX.Element {
           </>
         )}
       </Skeleton>
-      <Center>
-        <Text as="span" bottom="0" pos="absolute" fontWeight="bold" fontSize={12}>
+      <Center as="footer" py="1">
+        <Text as="span" bottom="0" pos="static" fontWeight="bold" fontSize={12}>
           Sources:
           <Text as="span" color="blue.500" decoration="underline" fontWeight="light">
             <Text

--- a/src/app/content/Content.tsx
+++ b/src/app/content/Content.tsx
@@ -59,7 +59,7 @@ export function Content({ term }: ContentProps): JSX.Element {
       <Center>
         <Text as="span" fontWeight="bold" fontSize={12}>
           Sources:
-          <Text as="span" color="blue.500" decoration="underline" fontWeight="light">
+          <Text as="span" color="blue.500" fontWeight="light">
             <Text
               as="a"
               href={`https://www.uvic.ca/calendar/undergrad/index.php#/courses/${data?.pid}`}
@@ -74,6 +74,7 @@ export function Content({ term }: ContentProps): JSX.Element {
               href={`https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse?term_in=${term}&subj_in=${data?.subject}&crse_in=${data?.code}&schd_in=`}
               target="_blank"
               _hover={{ color: 'blue' }}
+              ml="2"
             >
               UVic Class Schedule Listings
             </Text>

--- a/src/app/content/Content.tsx
+++ b/src/app/content/Content.tsx
@@ -57,7 +57,7 @@ export function Content({ term }: ContentProps): JSX.Element {
       </Box>
       <Spacer />
       <Center>
-        <Text as="span" fontWeight="bold" fontSize={12} mb={5}>
+        <Text as="span" fontWeight="bold" fontSize={12} mb={2}>
           Sources:
           <Text as="span" color="blue.500" fontWeight="light">
             <Text

--- a/src/app/content/Content.tsx
+++ b/src/app/content/Content.tsx
@@ -67,7 +67,7 @@ export function Content({ term }: ContentProps): JSX.Element {
               mx="3"
               _hover={{ color: 'blue' }}
             >
-              {`UVic Undergraduate Calendar ${new Date().getFullYear()}`}
+              UVic Undergraduate Calendar
             </Text>
             <Text
               as="a"

--- a/src/app/content/Content.tsx
+++ b/src/app/content/Content.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Flex, Heading, Skeleton, Text } from '@chakra-ui/react';
+import { Box, Center, Flex, Heading, Skeleton, Spacer, Text } from '@chakra-ui/react';
 import { useSearchParams } from 'react-router-dom';
 
 import { Term, useGetCourse } from '../../shared/fetchers';
@@ -23,38 +23,41 @@ export function Content({ term }: ContentProps): JSX.Element {
   console.log(data);
 
   return (
-    <Box width={['container.md', 'container.lg', 'container.xl']} bg="white" p={4} zIndex={60}>
-      <Flex
-        justifyItems="center"
-        alignItems={{ base: 'start', sm: 'center' }}
-        direction={{ base: 'column', sm: 'row' }}
-      >
-        <Heading mr="5" size="2xl" as="h2" whiteSpace="pre" color="black">{`${data?.subject || ''} ${
-          data?.code || ''
-        }`}</Heading>
-        {!loading && data && (
-          <Heading size="lg" as="h3" color="gray">
-            {data.title}
-          </Heading>
-        )}
-      </Flex>
-      <Skeleton isLoaded={!loading}>
-        {data && (
-          <>
-            <CourseInfo
-              subject={data.subject}
-              code={data.code}
-              title={data.title}
-              description={data.description || ''}
-              credits={data.credits}
-              hours={data.hoursCatalog}
-            />
-            <SectionsContainer term={term} subject={data?.subject} code={data?.code} />
-          </>
-        )}
-      </Skeleton>
-      <Center as="footer" py="1">
-        <Text as="span" bottom="0" pos="static" fontWeight="bold" fontSize={12}>
+    <Flex width={['container.md', 'container.lg', 'container.xl']} flexDirection="column" minH="100%">
+      <Box bg="white" p={4} zIndex={60}>
+        <Flex
+          justifyItems="center"
+          alignItems={{ base: 'start', sm: 'center' }}
+          direction={{ base: 'column', sm: 'row' }}
+        >
+          <Heading mr="5" size="2xl" as="h2" whiteSpace="pre" color="black">{`${data?.subject || ''} ${
+            data?.code || ''
+          }`}</Heading>
+          {!loading && data && (
+            <Heading size="lg" as="h3" color="gray">
+              {data.title}
+            </Heading>
+          )}
+        </Flex>
+        <Skeleton isLoaded={!loading}>
+          {data && (
+            <>
+              <CourseInfo
+                subject={data.subject}
+                code={data.code}
+                title={data.title}
+                description={data.description || ''}
+                credits={data.credits}
+                hours={data.hoursCatalog}
+              />
+              <SectionsContainer term={term} subject={data?.subject} code={data?.code} />
+            </>
+          )}
+        </Skeleton>
+      </Box>
+      <Spacer />
+      <Center>
+        <Text as="span" fontWeight="bold" fontSize={12}>
           Sources:
           <Text as="span" color="blue.500" decoration="underline" fontWeight="light">
             <Text
@@ -77,6 +80,6 @@ export function Content({ term }: ContentProps): JSX.Element {
           </Text>
         </Text>
       </Center>
-    </Box>
+    </Flex>
   );
 }

--- a/src/app/content/Content.tsx
+++ b/src/app/content/Content.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, Skeleton } from '@chakra-ui/react';
+import { Box, Center, Flex, Heading, Skeleton, Text } from '@chakra-ui/react';
 import { useSearchParams } from 'react-router-dom';
 
 import { Term, useGetCourse } from '../../shared/fetchers';
@@ -6,13 +6,13 @@ import { Term, useGetCourse } from '../../shared/fetchers';
 import { CourseInfo } from './components/Course';
 import { SectionsContainer } from './containers/Section';
 
-export interface ContentProps {
+export type ContentProps = {
   /**
    * Term Selected
    * Determines what term the subjects and courses are from
    */
   term: Term;
-}
+};
 
 /**
  * Primary UI component for content
@@ -20,6 +20,7 @@ export interface ContentProps {
 export function Content({ term }: ContentProps): JSX.Element {
   const [searchParams] = useSearchParams();
   const { data, loading } = useGetCourse({ term, pid: searchParams.get('pid') || '' });
+  console.log(data);
 
   return (
     <Box width={['container.md', 'container.lg', 'container.xl']} bg="white" p={4} zIndex={60}>
@@ -52,6 +53,30 @@ export function Content({ term }: ContentProps): JSX.Element {
           </>
         )}
       </Skeleton>
+      <Center>
+        <Text as="span" bottom="0" pos="absolute" fontWeight="bold" fontSize={12}>
+          Sources:
+          <Text as="span" color="blue.500" decoration="underline" fontWeight="light">
+            <Text
+              as="a"
+              href={`https://www.uvic.ca/calendar/undergrad/index.php#/courses/${data?.pid}`}
+              target="_blank"
+              mx="3"
+              _hover={{ color: 'blue' }}
+            >
+              {`UVic Undergraduate Calendar ${new Date().getFullYear()}`}
+            </Text>
+            <Text
+              as="a"
+              href={`https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse?term_in=${term}&subj_in=${data?.subject}&crse_in=${data?.code}&schd_in=`}
+              target="_blank"
+              _hover={{ color: 'blue' }}
+            >
+              UVic Class Schedule Listings
+            </Text>
+          </Text>
+        </Text>
+      </Center>
     </Box>
   );
 }

--- a/src/app/content/components/Section.tsx
+++ b/src/app/content/components/Section.tsx
@@ -138,9 +138,9 @@ export function SectionInfo({
             href={`https://www.uvic.ca/BAN1P/bwckschd.p_disp_detail_sched?term_in=${term}&crn_in=${crn}`}
             target="_blank"
             _hover={{ color: 'blue' }}
-            ml="2"
+            ml="1"
           >
-            UVic Detailed Class Information
+            UVic
           </Text>
         </Text>
       </Text>

--- a/src/app/content/components/Section.tsx
+++ b/src/app/content/components/Section.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading } from '@chakra-ui/layout';
+import { Box, Heading, Text } from '@chakra-ui/layout';
 import {
   Accordion,
   AccordionButton,
@@ -14,6 +14,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@chakra-ui/react';
+import { useParams } from 'react-router';
 
 import { MeetingTimes, Seat } from '../../../shared/fetchers';
 
@@ -66,6 +67,8 @@ export function SectionInfo({
   const isASYNC = additionalNotes?.indexOf('asynchronous') !== -1;
   const isSENG = additionalNotes?.indexOf('Reserved for BSENG students') !== -1;
   const isCSC = additionalNotes?.indexOf('Reserved for students in a Computer Science program') !== -1;
+
+  const { term } = useParams();
 
   return (
     <Box as="section" bg="white" color="black" my="4" boxShadow="md" p="3" rounded="lg">
@@ -127,6 +130,20 @@ export function SectionInfo({
           <SeatInfo seat={seat} />
         </Box>
       </Box>
+      <Text as="span" fontWeight="bold" fontSize={10} align="right" w="100%" display="block">
+        Source:
+        <Text as="span" color="blue.500" decoration="underline" fontWeight="light">
+          <Text
+            as="a"
+            href={`https://www.uvic.ca/BAN1P/bwckschd.p_disp_detail_sched?term_in=${term}&crn_in=${crn}`}
+            target="_blank"
+            _hover={{ color: 'blue' }}
+            ml="2"
+          >
+            UVic Detailed Class Information
+          </Text>
+        </Text>
+      </Text>
     </Box>
   );
 }

--- a/src/app/content/components/Section.tsx
+++ b/src/app/content/components/Section.tsx
@@ -130,9 +130,9 @@ export function SectionInfo({
           <SeatInfo seat={seat} />
         </Box>
       </Box>
-      <Text as="span" fontWeight="bold" fontSize={10} align="right" w="100%" display="block">
+      <Text as="span" fontWeight="bold" fontSize={12} align="right" w="100%" display="block">
         Source:
-        <Text as="span" color="blue.500" decoration="underline" fontWeight="light">
+        <Text as="span" color="blue.500" fontWeight="light">
           <Text
             as="a"
             href={`https://www.uvic.ca/BAN1P/bwckschd.p_disp_detail_sched?term_in=${term}&crn_in=${crn}`}


### PR DESCRIPTION
## Overview
<!-- Replace `XX` with the issue # you're working on -->
Closes #106 

<!-- Give a brief overview of the changes made -->
Added links to the UVic undergrad calendar and class schedule listings at bottom of content component. The links send the user in a new tab to the courses respective pages for the Kuali and BAN1P data. I've purposely left off the section details link because there would have to be a link for each section and that can be accessed from the listings link.

<!-- Provide a screenshot of any frontend changess -->
<img width="1533" alt="Screen Shot 2021-04-27 at 7 18 08 PM" src="https://user-images.githubusercontent.com/53020925/116337110-7c726b00-a78e-11eb-8c09-5fd658b06a1b.png">
<img width="758" alt="Screen Shot 2021-04-27 at 7 27 04 PM" src="https://user-images.githubusercontent.com/53020925/116337175-901dd180-a78e-11eb-9690-a0df14c8dcad.png">

