### PR TITLE
Add mobile view warning

### DIFF
--- a/src/app/mobile/index.tsx
+++ b/src/app/mobile/index.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 // TODO: real mobile functionality
 export function Mobile(): JSX.Element | null {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [isMobile] = useMediaQuery('(max-width: 600px)');
+  const [isMobile] = useMediaQuery('(max-width: 1030px)');
 
   useEffect(() => {
     onOpen();
@@ -18,7 +18,7 @@ export function Mobile(): JSX.Element | null {
         <ModalBody textAlign="center">
           (╯°□°)╯︵ ┻━┻<Text my="5px"> Hey! We're still not quite there with mobile support.</Text>
           <Text>
-            Please use a <Text as="strong">tablet</Text> or <Text as="strong">desktop</Text> to get the best experience
+            Please use a <Text as="strong">desktop</Text> to get the best experience
           </Text>
         </ModalBody>
       </ModalContent>

--- a/src/app/mobile/index.tsx
+++ b/src/app/mobile/index.tsx
@@ -1,0 +1,27 @@
+import { Modal, ModalBody, ModalContent, ModalOverlay, Text, useDisclosure, useMediaQuery } from '@chakra-ui/react';
+import { useEffect } from 'react';
+
+// TODO: real mobile functionality
+export function Mobile(): JSX.Element | null {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [isMobile] = useMediaQuery('(max-width: 600px)');
+
+  useEffect(() => {
+    onOpen();
+  }, [onOpen]);
+
+  if (!isMobile) return null;
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent w="90%" minW="200px" zIndex={999}>
+        <ModalBody textAlign="center">
+          (╯°□°)╯︵ ┻━┻<Text my="5px"> Hey! We're still not quite there with mobile support.</Text>
+          <Text>
+            Please use a <Text as="strong">tablet</Text> or <Text as="strong">desktop</Text> to get the best experience
+          </Text>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,17 @@
-import { ChakraProvider } from '@chakra-ui/react';
+import {
+  ChakraProvider,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+  useMediaQuery,
+} from '@chakra-ui/react';
 import * as Sentry from '@sentry/react';
 import { Integrations } from '@sentry/tracing';
 import algoliasearch from 'algoliasearch';
-import React from 'react';
+import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { Helmet } from 'react-helmet';
 import { InstantSearch } from 'react-instantsearch-dom';
@@ -25,12 +34,37 @@ Sentry.init({
 
 const searchClient = algoliasearch('CR92D3S394', '5477854d63b676fe021f8f83f5839a3a');
 
+function Mobile(): JSX.Element | null {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [isMobile] = useMediaQuery('(max-width: 600px)');
+
+  useEffect(() => {
+    onOpen();
+  }, [onOpen]);
+
+  if (!isMobile) return null;
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent w="90%" minW="200px" zIndex={999}>
+        <ModalBody textAlign="center">
+          (╯°□°)╯︵ ┻━┻<Text my="5px"> Hey! We're still not quite there with mobile support.</Text>
+          <Text>
+            Please use a <Text as="strong">tablet</Text> or <Text as="strong">desktop</Text> to get the best experience
+          </Text>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}
+
 ReactDOM.render(
   <React.StrictMode>
     <RestfulProvider base={process.env.NODE_ENV === 'production' ? '/api' : 'https://clockwork.vikelabs.dev/api'}>
       <InstantSearch searchClient={searchClient} indexName="dev_uvic">
         <ChakraProvider portalZIndex={999}>
           <Helmet titleTemplate="%s · clockwork" defaultTitle="clockwork · We make school easier" />
+          <Mobile />
           <Routes />
         </ChakraProvider>
       </InstantSearch>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,22 +1,14 @@
-import {
-  ChakraProvider,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalOverlay,
-  Text,
-  useDisclosure,
-  useMediaQuery,
-} from '@chakra-ui/react';
+import { ChakraProvider } from '@chakra-ui/react';
 import * as Sentry from '@sentry/react';
 import { Integrations } from '@sentry/tracing';
 import algoliasearch from 'algoliasearch';
-import React, { useEffect } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import { Helmet } from 'react-helmet';
 import { InstantSearch } from 'react-instantsearch-dom';
 import { RestfulProvider } from 'restful-react';
 
+import { Mobile } from './app/mobile';
 import reportWebVitals from './reportWebVitals';
 import { Routes } from './routes';
 
@@ -33,30 +25,6 @@ Sentry.init({
 });
 
 const searchClient = algoliasearch('CR92D3S394', '5477854d63b676fe021f8f83f5839a3a');
-
-function Mobile(): JSX.Element | null {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const [isMobile] = useMediaQuery('(max-width: 600px)');
-
-  useEffect(() => {
-    onOpen();
-  }, [onOpen]);
-
-  if (!isMobile) return null;
-  return (
-    <Modal isOpen={isOpen} onClose={onClose} isCentered>
-      <ModalOverlay />
-      <ModalContent w="90%" minW="200px" zIndex={999}>
-        <ModalBody textAlign="center">
-          (╯°□°)╯︵ ┻━┻<Text my="5px"> Hey! We're still not quite there with mobile support.</Text>
-          <Text>
-            Please use a <Text as="strong">tablet</Text> or <Text as="strong">desktop</Text> to get the best experience
-          </Text>
-        </ModalBody>
-      </ModalContent>
-    </Modal>
-  );
-}
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,44 +1,14 @@
-import { useDisclosure } from '@chakra-ui/hooks';
-import { Text } from '@chakra-ui/layout';
-import { useMediaQuery } from '@chakra-ui/media-query';
-import { Modal, ModalBody, ModalContent, ModalOverlay } from '@chakra-ui/modal';
-import { useEffect } from 'react';
 import { BrowserRouter, Routes as ReactRouterRoutes, Route } from 'react-router-dom';
 
 import { Calendar } from './pages/calendar';
 import { Home } from './pages/home';
 import { Scheduler } from './pages/scheduler/scheduler';
 
-// For our lack of mobile support :-)
-function Mobile(): JSX.Element {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-
-  useEffect(() => {
-    onOpen();
-  }, [onOpen]);
-
-  return (
-    <Modal isOpen={isOpen} onClose={onClose} isCentered>
-      <ModalOverlay />
-      <ModalContent w="90%" minW="200px" zIndex={999}>
-        <ModalBody textAlign="center">
-          (╯°□°)╯︵ ┻━┻<Text my="5px"> Hey! We're still not quite there with mobile support.</Text>
-          <Text>
-            Please use a <Text as="strong">tablet</Text> or <Text as="strong">desktop</Text> to get the best experience
-          </Text>
-        </ModalBody>
-      </ModalContent>
-    </Modal>
-  );
-}
-
 // TODO: use nested routes but it doesn't work right now
-export function Routes(): JSX.Element {
-  const [isMobile] = useMediaQuery('(max-width: 600px)');
 
+export function Routes(): JSX.Element {
   return (
     <BrowserRouter>
-      {isMobile && <Mobile />}
       <ReactRouterRoutes>
         <Route path="/" element={<Home />} />
         <Route path="/calendar" element={<Calendar />} />

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,14 +1,44 @@
+import { useDisclosure } from '@chakra-ui/hooks';
+import { Text } from '@chakra-ui/layout';
+import { useMediaQuery } from '@chakra-ui/media-query';
+import { Modal, ModalBody, ModalContent, ModalOverlay } from '@chakra-ui/modal';
+import { useEffect } from 'react';
 import { BrowserRouter, Routes as ReactRouterRoutes, Route } from 'react-router-dom';
 
 import { Calendar } from './pages/calendar';
 import { Home } from './pages/home';
 import { Scheduler } from './pages/scheduler/scheduler';
 
-// TODO: use nested routes but it doesn't work right now
+// For our lack of mobile support :-)
+function Mobile(): JSX.Element {
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
+  useEffect(() => {
+    onOpen();
+  }, [onOpen]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent w="90%" minW="200px" zIndex={999}>
+        <ModalBody textAlign="center">
+          (╯°□°)╯︵ ┻━┻<Text my="5px"> Hey! We're still not quite there with mobile support.</Text>
+          <Text>
+            Please use a <Text as="strong">tablet</Text> or <Text as="strong">desktop</Text> to get the best experience
+          </Text>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+// TODO: use nested routes but it doesn't work right now
 export function Routes(): JSX.Element {
+  const [isMobile] = useMediaQuery('(max-width: 600px)');
+
   return (
     <BrowserRouter>
+      {isMobile && <Mobile />}
       <ReactRouterRoutes>
         <Route path="/" element={<Home />} />
         <Route path="/calendar" element={<Calendar />} />


### PR DESCRIPTION
## Overview
<!-- Replace `XX` with the issue # you're working on -->

<!-- Give a brief overview of the changes made -->
Jumped on the opportunity to add a warning for anyone trying to access the site on mobile. Modal pops up when the screen gets < 600px wide. It can be closed by the user, but this can be easily changed if we want to fully block the user from using the page.

<!-- Provide a screenshot of any frontend changess -->
<img width="479" alt="Screen Shot 2021-05-01 at 9 18 59 AM" src="https://user-images.githubusercontent.com/53020925/116788427-597dda80-aa5e-11eb-84ae-4c84a2f3a073.png">

