### PR TITLE
fix: stop having backend CI run if only frontend files change

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -6,6 +6,8 @@ on:
     branches: 
       - main
   pull_request:
+    paths:
+      - 'functions/**'
     branches:
       - main
 jobs:

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -8,6 +8,11 @@ on:
       - 'functions/**'
     branches: 
       - main
+  pull_request:
+    paths-ignore:
+      - 'functions/**'
+    branches:
+      - main
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - 'functions/**'
     branches: 
-      - main/**
+      - main
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -7,12 +7,7 @@ on:
     paths-ignore:
       - 'functions/**'
     branches: 
-      - main
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - 'functions/**'
+      - main/**
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -1,0 +1,18 @@
+name: Promote to Production
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'     
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Test scenario tags'
+        required: true
+jobs:
+  printInputs:
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo "Log level: ${{ github.event.inputs.logLevel }}"
+        echo "Tags: ${{ github.event.inputs.tags }}" 


### PR DESCRIPTION
## Overview
<!-- Replace `XX` with the issue # you're working on -->
Closes #XX
Stops the backend CI running if only frontend files change. Also adds a test "Promote to Production" action (which doesn't actually do that).  

<!-- Give a brief overview of the changes made -->

<!-- Provide a screenshot of any frontend changess -->
